### PR TITLE
Fix handling of non-XML responses from SOAP server

### DIFF
--- a/src/Message/Traits/HasSoapRequestTrait.php
+++ b/src/Message/Traits/HasSoapRequestTrait.php
@@ -55,9 +55,21 @@ trait HasSoapRequestTrait
         if (empty($response)) {
             throw new \Exception('ERROR: Nu am putut comunica cu serverul PO pentru operatiunea de autorizare!');
         }
-        Xml::validate($response, $this->getSoapResponseValidationUrl());
-        $responseObject = simplexml_load_string($response, 'SimpleXMLElement', LIBXML_NOCDATA);
-        return $responseObject;
+        
+        // Check if response is XML format (starts with '<')
+        if (substr(trim($response), 0, 1) !== '<') {
+            // If not XML, throw an exception with the actual server response
+            throw new \Exception('Server response is not in XML format: ' . $response);
+        }
+        
+        try {
+            Xml::validate($response, $this->getSoapResponseValidationUrl());
+            $responseObject = simplexml_load_string($response, 'SimpleXMLElement', LIBXML_NOCDATA);
+            return $responseObject;
+        } catch (\Exception $e) {
+            // If XML validation or parsing fails, throw an exception with details
+            throw new \Exception('Failed to process XML response: ' . $e->getMessage() . '. Original response: ' . $response);
+        }
     }
 
     /**


### PR DESCRIPTION
Problem
When receiving a non-XML response from the SOAP server, the library throws an irrelevant XML parsing error (Start tag expected, '<' not found) instead of the actual error from the server.

Solution
Added a check to verify if the server response starts with the < character (indicating XML format)

If the response is not in XML format, a descriptive exception is thrown containing the original response text

Added a try/catch block for better error handling during XML validation and parsing

Improved error messages to include the original server response

Impact
Library users will now receive clear and informative errors containing the actual server response, making issue diagnosis easier.